### PR TITLE
:construction_worker: Fix linking test coverage file to Codecov

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -70,4 +70,5 @@ jobs:
       - name: Send converage
         uses: codecov/codecov-action@v1
         with:
+          file: fastlane/test_output/cobertura.xml
           fail_ci_if_error: false

--- a/Gemfile
+++ b/Gemfile
@@ -3,4 +3,4 @@ source "https://rubygems.org"
 # Xcode
 gem 'cocoapods', '1.7.3'
 gem 'fastlane', '2.154.0'
-
+gem 'slather', '2.4.9'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -28,6 +28,7 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     babosa (1.0.3)
     claide (1.0.3)
+    clamp (1.3.1)
     cocoapods (1.7.3)
       activesupport (>= 4.0.2, < 5)
       claide (>= 1.0.2, < 2.0)
@@ -163,6 +164,7 @@ GEM
     memoist (0.16.2)
     mini_magick (4.10.1)
     mini_mime (1.0.2)
+    mini_portile2 (2.4.0)
     minitest (5.14.1)
     molinillo (0.6.6)
     multi_json (1.15.0)
@@ -171,6 +173,8 @@ GEM
     nap (1.1.0)
     naturally (2.2.0)
     netrc (0.11.0)
+    nokogiri (1.10.10)
+      mini_portile2 (~> 2.4.0)
     os (1.1.1)
     plist (3.5.0)
     public_suffix (2.0.5)
@@ -193,6 +197,12 @@ GEM
       CFPropertyList
       naturally
     slack-notifier (2.3.2)
+    slather (2.4.9)
+      CFPropertyList (>= 2.2, < 4)
+      activesupport (>= 4.0.2, < 5)
+      clamp (~> 1.3)
+      nokogiri (~> 1.8)
+      xcodeproj (~> 1.7)
     terminal-notifier (2.0.0)
     terminal-table (1.8.0)
       unicode-display_width (~> 1.1, >= 1.1.1)
@@ -226,6 +236,7 @@ PLATFORMS
 DEPENDENCIES
   cocoapods (= 1.7.3)
   fastlane (= 2.154.0)
+  slather (= 2.4.9)
 
 BUNDLED WITH
    2.1.4

--- a/UseCaseKit.xcodeproj/xcshareddata/xcschemes/UseCaseKitTests.xcscheme
+++ b/UseCaseKit.xcodeproj/xcshareddata/xcschemes/UseCaseKitTests.xcscheme
@@ -5,39 +5,13 @@
    <BuildAction
       parallelizeBuildables = "YES"
       buildImplicitDependencies = "YES">
-      <BuildActionEntries>
-         <BuildActionEntry
-            buildForTesting = "YES"
-            buildForRunning = "YES"
-            buildForProfiling = "YES"
-            buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
-            <BuildableReference
-               BuildableIdentifier = "primary"
-               BlueprintIdentifier = "UseCaseKit::UseCaseKit"
-               BuildableName = "UseCaseKit.framework"
-               BlueprintName = "UseCaseKit"
-               ReferencedContainer = "container:UseCaseKit.xcodeproj">
-            </BuildableReference>
-         </BuildActionEntry>
-      </BuildActionEntries>
    </BuildAction>
    <TestAction
       buildConfiguration = "Debug"
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
       selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
       shouldUseLaunchSchemeArgsEnv = "YES"
-      codeCoverageEnabled = "YES"
-      onlyGenerateCoverageForSpecifiedTargets = "YES">
-      <CodeCoverageTargets>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "UseCaseKit::UseCaseKit"
-            BuildableName = "UseCaseKit.framework"
-            BlueprintName = "UseCaseKit"
-            ReferencedContainer = "container:UseCaseKit.xcodeproj">
-         </BuildableReference>
-      </CodeCoverageTargets>
+      codeCoverageEnabled = "YES">
       <Testables>
          <TestableReference
             skipped = "NO">
@@ -68,15 +42,6 @@
       savedToolIdentifier = ""
       useCustomWorkingDirectory = "NO"
       debugDocumentVersioning = "YES">
-      <MacroExpansion>
-         <BuildableReference
-            BuildableIdentifier = "primary"
-            BlueprintIdentifier = "UseCaseKit::UseCaseKit"
-            BuildableName = "UseCaseKit.framework"
-            BlueprintName = "UseCaseKit"
-            ReferencedContainer = "container:UseCaseKit.xcodeproj">
-         </BuildableReference>
-      </MacroExpansion>
    </ProfileAction>
    <AnalyzeAction
       buildConfiguration = "Debug">

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -7,7 +7,16 @@ platform :ios do
   lane :test do
     scan(scheme: "UseCaseKit",
          clean: true,
+         code_coverage: true,
          device: "iPhone 11")
+
+    slather(workspace: "UseCaseKit.xcworkspace",
+            proj: "UseCaseKit.xcodeproj",
+            scheme: "UseCaseKit",
+            output_directory: "fastlane/test_output",
+            ignore: "Pods/**",
+            cobertura_xml: true,
+            verbose: true)
   end
 
 end


### PR DESCRIPTION
Overview
===
Currently, Xcode sends test coverage data to Codecov after complete unit test.
But Codecov cannot display correct coverage data because Codecov cannot support Xcode test coverage format.

So, added script that convert Xcode formatted coverage data to Codecov supported format after Unit test.