### PR TITLE
:sparkles: Added minimum operator to StateRelay

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # UseCaseKit
 
-![CI](https://github.com/crexista/UseCaseKit/workflows/CI/badge.svg)
+![CI](https://github.com/crexista/UseCaseKit/workflows/CI/badge.svg) [![codecov](https://codecov.io/gh/crexista/UseCaseKit/branch/master/graph/badge.svg)](https://codecov.io/gh/crexista/UseCaseKit)
 
 A description of this package.

--- a/Sources/UseCaseKit/StateRelay+Extension.swift
+++ b/Sources/UseCaseKit/StateRelay+Extension.swift
@@ -1,0 +1,46 @@
+//
+// Copyright © 2020 @crexista. All rights reserved.
+//
+
+import Foundation
+
+public extension StateRelay {
+
+    /// This method converts output state to `T`
+    ///
+    /// - Parameter transform: This closure convert state that is received from upstream.
+    /// - Returns: A relay that uses the provided closure to map elements fron the upstream relay
+    ///            to new elements that it then relays
+    func map<T>(_ transform: @escaping (State) -> T) -> StateRelay<T> {
+        return StateRelay<T> { handler in
+            self.sink { handler(transform($0)) }
+        }
+    }
+
+    /// This method relays only the state that matches the conditions which is provided by closure.
+    ///
+    /// - Parameter isIncluded: A closure that returns Boolean value whether state will be relayed or not.
+    /// - Returns: A Relay that relays all elements that satisfy the closure.
+    func filter(_ isIncluded: @escaping (State) -> Bool) -> StateRelay<State> {
+        return StateRelay<State> { handler in
+            self.sink {
+                guard isIncluded($0) else { return }
+                handler($0)
+            }
+        }
+    }
+
+    /// This method relays only elements that don’t match the previous element.
+    ///
+    /// - Returns: A Relay that consumes — rather than relays — duplicate elements.
+    func removeDuplicates() -> StateRelay<State> {
+        return StateRelay { handler in
+            var prev: State?
+            self.sink {
+                guard prev != $0 else { return }
+                prev = $0
+                handler($0)
+            }
+        }
+    }
+}

--- a/Tests/UseCaseKitTests/StateRelayFilterSpec.swift
+++ b/Tests/UseCaseKitTests/StateRelayFilterSpec.swift
@@ -1,0 +1,48 @@
+//
+// Copyright © 2020 @crexista. All rights reserved.
+//
+
+import XCTest
+@testable import UseCaseKit
+import Quick
+import Nimble
+
+class StateRelayFilterSpec: QuickSpec {
+
+    override func spec() {
+        describe("StateRelay") {
+            let convertStr = "Test"
+            let mapFunc: (Int) -> String = { "\(convertStr) - \($0)" }
+
+            context("if it has source callback") {
+                let initialNum: Int = 1
+
+                it("relays state when that state mathes condition") {
+                    let stateRelay = StateRelay(handler: { subscriber in subscriber(initialNum) })
+                    waitUntil { end in
+                        stateRelay
+                            .filter { $0 == initialNum }
+                            .sink { _ in end() }
+                    }
+                }
+
+                it("doesn't relays state when that state mathes condition") {
+                    let stateRelay = StateRelay(handler: { subscriber in subscriber(initialNum) })
+                    let exp = self.expectation(description: "Do not call")
+                    stateRelay.filter { $0 != initialNum }.sink { _ in exp.fulfill() }
+                    expect(XCTWaiter.wait(for: [exp], timeout: 1.0)) == .timedOut
+                }
+            }
+
+            context("if it has empty source") {
+                it("calles subscribing method") {
+                    let stateRelay: StateRelay<Int> = StateRelay { _ in }
+                    let exp = self.expectation(description: "Do not call")
+                    stateRelay.map(mapFunc).sink { _ in  exp.fulfill() }
+                    expect(XCTWaiter.wait(for: [exp], timeout: 1.0)) == .timedOut
+                }
+
+            }
+        }
+    }
+}

--- a/Tests/UseCaseKitTests/StateRelayMapSpec.swift
+++ b/Tests/UseCaseKitTests/StateRelayMapSpec.swift
@@ -1,0 +1,50 @@
+//
+// Copyright © 2020 @crexista. All rights reserved.
+//
+
+import XCTest
+@testable import UseCaseKit
+import Quick
+import Nimble
+
+class StateRelayMapSpec: QuickSpec {
+
+    override func spec() {
+        describe("StateRelay") {
+            let convertStr = "Test"
+            let mapFunc: (Int) -> String = { "\(convertStr) - \($0)" }
+
+            context("if it has source callback") {
+                let initialNum: Int = 1
+
+                it("calles subscribing method") {
+                    let stateRelay = StateRelay(handler: { subscriber in subscriber(initialNum) })
+                    waitUntil { end in
+                        stateRelay
+                            .map(mapFunc)
+                            .sink { _ in end() }
+                    }
+                }
+
+                it("convert Int state to String") {
+                    let stateRelay = StateRelay(handler: { subscriber in subscriber(initialNum) })
+                    waitUntil { end in
+                        stateRelay
+                            .map(mapFunc)
+                            .sink { expect($0) == mapFunc(initialNum); end() }
+                    }
+                }
+            }
+
+            context("if it has empty source") {
+                it("calles subscribing method") {
+                    let stateRelay: StateRelay<Int> = StateRelay { _ in }
+                    let exp = self.expectation(description: "Do not call")
+                    stateRelay.map(mapFunc).sink { _ in  exp.fulfill() }
+                    expect(XCTWaiter.wait(for: [exp], timeout: 1.0)) == .timedOut
+                }
+
+            }
+        }
+    }
+}

--- a/Tests/UseCaseKitTests/StateRelaySpec.swift
+++ b/Tests/UseCaseKitTests/StateRelaySpec.swift
@@ -3,7 +3,7 @@ import XCTest
 import Quick
 import Nimble
 
-class StateRealySpec: QuickSpec {
+class StateRelaySpec: QuickSpec {
 
     override func spec() {
         describe("StateRelay") {
@@ -19,7 +19,7 @@ class StateRealySpec: QuickSpec {
             }
 
             context("if it has empty source") {
-                it("calles subscribing method") {
+                it("doesn't calles subscribing method") {
                     let stateRelay: StateRelay<String> = StateRelay { _ in }
                     let exp = self.expectation(description: "Do not call")
                     stateRelay.sink { _ in  exp.fulfill() }

--- a/UseCaseKit.xcodeproj/project.pbxproj
+++ b/UseCaseKit.xcodeproj/project.pbxproj
@@ -27,6 +27,9 @@
 		DB91EAC424D6DB5900ED5A3A /* Nimble.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = DB91EAC224D6DB5900ED5A3A /* Nimble.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DB91EAC524D6DB5900ED5A3A /* Quick.framework in CopyFiles */ = {isa = PBXBuildFile; fileRef = DB91EAC324D6DB5900ED5A3A /* Quick.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		DB91EAD324D7D66300ED5A3A /* StateRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB91EAD224D7D66300ED5A3A /* StateRelay.swift */; };
+		DB91EAD524D80AB100ED5A3A /* StateRelay+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB91EAD424D80AB100ED5A3A /* StateRelay+Extension.swift */; };
+		DB91EAD824D8113B00ED5A3A /* StateRelayMapSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB91EAD624D8111D00ED5A3A /* StateRelayMapSpec.swift */; };
+		DB91EADA24D82B7600ED5A3A /* StateRelayFilterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB91EAD924D82B7600ED5A3A /* StateRelayFilterSpec.swift */; };
 		OBJ_29 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
 		OBJ_40 /* StateRelaySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* StateRelaySpec.swift */; };
 		OBJ_43 /* UseCaseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "UseCaseKit::UseCaseKit::Product" /* UseCaseKit.framework */; };
@@ -74,6 +77,9 @@
 		DB91EAC224D6DB5900ED5A3A /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
 		DB91EAC324D6DB5900ED5A3A /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		DB91EAD224D7D66300ED5A3A /* StateRelay.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateRelay.swift; sourceTree = "<group>"; };
+		DB91EAD424D80AB100ED5A3A /* StateRelay+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StateRelay+Extension.swift"; sourceTree = "<group>"; };
+		DB91EAD624D8111D00ED5A3A /* StateRelayMapSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateRelayMapSpec.swift; sourceTree = "<group>"; };
+		DB91EAD924D82B7600ED5A3A /* StateRelayFilterSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateRelayFilterSpec.swift; sourceTree = "<group>"; };
 		OBJ_12 /* StateRelaySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateRelaySpec.swift; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		"UseCaseKit::UseCaseKit::Product" /* UseCaseKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = UseCaseKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -142,6 +148,8 @@
 			isa = PBXGroup;
 			children = (
 				OBJ_12 /* StateRelaySpec.swift */,
+				DB91EAD624D8111D00ED5A3A /* StateRelayMapSpec.swift */,
+				DB91EAD924D82B7600ED5A3A /* StateRelayFilterSpec.swift */,
 			);
 			name = UseCaseKitTests;
 			path = Tests/UseCaseKitTests;
@@ -182,6 +190,7 @@
 			isa = PBXGroup;
 			children = (
 				DB91EAD224D7D66300ED5A3A /* StateRelay.swift */,
+				DB91EAD424D80AB100ED5A3A /* StateRelay+Extension.swift */,
 			);
 			name = UseCaseKit;
 			path = Sources/UseCaseKit;
@@ -318,6 +327,7 @@
 			buildActionMask = 0;
 			files = (
 				DB91EAD324D7D66300ED5A3A /* StateRelay.swift in Sources */,
+				DB91EAD524D80AB100ED5A3A /* StateRelay+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -334,6 +344,8 @@
 			buildActionMask = 0;
 			files = (
 				OBJ_40 /* StateRelaySpec.swift in Sources */,
+				DB91EADA24D82B7600ED5A3A /* StateRelayFilterSpec.swift in Sources */,
+				DB91EAD824D8113B00ED5A3A /* StateRelayMapSpec.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};

--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,8 @@
+codecov:
+  require_ci_to_pass: yes
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+


### PR DESCRIPTION
Overview
===
- Added minimum operator `map`, `filter`, `removeDuplicates` to `StateRelay`.

Note
===
- StateRelay's removeDuplicates cannot be test now.