### PR TITLE
:sparkles: Added StatePublisher

### DIFF
--- a/Sources/UseCaseKit/StatePublisher.swift
+++ b/Sources/UseCaseKit/StatePublisher.swift
@@ -1,0 +1,40 @@
+//
+// Copyright © 2020 @crexista. All rights reserved.
+//
+
+import Foundation
+
+class StatePublisher<State: Equatable>: StateRelay<State> {
+    private class Container {
+        var state: State
+
+        init(state: State) {
+            self.state = state
+        }
+    }
+
+    private var subscribers: [Subscriber<State>] = []
+    private var container: Container
+
+    var state: State { return container.state }
+
+    init(state: State) {
+        let container = Container(state: state)
+        self.container = container
+        super.init { $0(container.state) }
+    }
+
+    /// This method publish state and save
+    ///
+    /// - Parameter state: The state that is emitted to recivers via StateRelay
+    func publish(_ state: State) {
+        self.container.state = state
+        subscribers.forEach { $0(state) }
+    }
+
+    override func sink(receiver: @escaping Subscriber<State>) {
+        super.sink(receiver: receiver)
+        subscribers.append(receiver)
+    }
+
+}

--- a/Tests/UseCaseKitTests/StatePublisherSpec.swift
+++ b/Tests/UseCaseKitTests/StatePublisherSpec.swift
@@ -1,0 +1,77 @@
+//
+// Copyright © 2020 @crexista. All rights reserved.
+//
+
+@testable import UseCaseKit
+import Quick
+import Nimble
+
+class StatePublisherSpec: QuickSpec {
+
+    override func spec() {
+        let initialState = "test"
+        var publisher = StatePublisher(state: initialState)
+
+        describe("StatePublisher") {
+            context("before publish") {
+
+                beforeEach {
+                    publisher = StatePublisher(state: initialState)
+                }
+
+                it("sends to state that is retained when is sinked") {
+                    waitUntil { end in
+                        publisher.sink { expect($0) == initialState; end() }
+                    }
+                }
+
+                it("sends state to receiver for each sink") {
+                    let first = self.expectation(description: "first")
+                    let second = self.expectation(description: "second")
+                    publisher.sink { expect($0) == initialState; first.fulfill() }
+                    publisher.sink { expect($0) == initialState; second.fulfill() }
+                    expect(XCTWaiter.wait(for: [first, second], timeout: 1.0, enforceOrder: true)) == .completed
+                }
+
+                it("returns current state that is initial state") {
+                    expect(publisher.state) == initialState
+                }
+            }
+
+            context("after publish") {
+                let newState = "test2"
+                beforeEach {
+                    publisher = StatePublisher(state: initialState)
+                    publisher.publish(newState)
+                }
+
+                it("sends state that published after sending initial state") {
+                    let first = self.expectation(description: "first")
+                    publisher.filter { $0 != initialState }
+                        .sink { expect($0) == newState; first.fulfill() }
+
+                    expect(XCTWaiter.wait(for: [first], timeout: 1.0)) == .completed
+                }
+
+                it("multicast state to each receivers") {
+                    let first = self.expectation(description: "first")
+                    let second = self.expectation(description: "second")
+
+                    publisher.filter { $0 != initialState }
+                        .sink { expect($0) == newState; first.fulfill() }
+
+                    publisher.filter { $0 != initialState }
+                        .sink { expect($0) == newState; second.fulfill() }
+
+                    expect(XCTWaiter.wait(for: [first, second], timeout: 1.0)) == .completed
+
+                }
+
+                it("return new state") {
+                    expect(publisher.state) == newState
+                }
+            }
+        }
+
+    }
+}

--- a/Tests/UseCaseKitTests/StateRelayRemoveDuplicates.swift
+++ b/Tests/UseCaseKitTests/StateRelayRemoveDuplicates.swift
@@ -1,0 +1,69 @@
+//
+// Copyright © 2020 @crexista. All rights reserved.
+//
+
+@testable import UseCaseKit
+import Quick
+import Nimble
+
+class StateRelayRemoveDuplicates: QuickSpec {
+
+    override func spec() {
+        let initialState = "test"
+        let newState1 = "test1"
+        let newState2 = "test2"
+        var publisher: StatePublisher<String>!
+
+        describe("StateRelay") {
+            context("send no state") {
+
+                beforeEach { publisher = StatePublisher(state: initialState) }
+
+                it("does not call receiver") {
+                    let calledOnce = self.expectation(description: "Called once")
+                    publisher.filter { $0 != initialState }
+                        .removeDuplicates()
+                        .sink { _ in calledOnce.fulfill() }
+                    expect(XCTWaiter.wait(for: [calledOnce], timeout: 1.0)) == .timedOut
+                }
+            }
+
+            context("send same state") {
+
+                beforeEach { publisher = StatePublisher(state: initialState) }
+
+                it("calles receiver closure once") {
+                    let calledOnce = self.expectation(description: "Called once")
+                    publisher.filter { $0 != initialState }
+                        .removeDuplicates()
+                        .sink { _ in calledOnce.fulfill() }
+                    publisher.publish(newState1)
+                    publisher.publish(newState1)
+                    expect(XCTWaiter.wait(for: [calledOnce], timeout: 1.0)) == .completed
+                }
+            }
+
+            context("send different state") {
+
+                beforeEach { publisher = StatePublisher(state: initialState) }
+
+                it("calles receiver closure once") {
+                    let first = self.expectation(description: "first")
+                    let second = self.expectation(description: "second")
+                    var count = 1
+                    publisher.filter { $0 != initialState }
+                        .removeDuplicates()
+                        .sink { _ in
+                            ((count == 1) ? first : second).fulfill()
+                            count += 1
+                        }
+                    publisher.publish(newState1)
+                    publisher.publish(newState2)
+                    expect(XCTWaiter.wait(for: [first, second], timeout: 1.0)) == .completed
+                }
+            }
+
+        }
+
+    }
+}

--- a/UseCaseKit.xcodeproj/project.pbxproj
+++ b/UseCaseKit.xcodeproj/project.pbxproj
@@ -30,6 +30,9 @@
 		DB91EAD524D80AB100ED5A3A /* StateRelay+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB91EAD424D80AB100ED5A3A /* StateRelay+Extension.swift */; };
 		DB91EAD824D8113B00ED5A3A /* StateRelayMapSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB91EAD624D8111D00ED5A3A /* StateRelayMapSpec.swift */; };
 		DB91EADA24D82B7600ED5A3A /* StateRelayFilterSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB91EAD924D82B7600ED5A3A /* StateRelayFilterSpec.swift */; };
+		DB91EADE24D89BD100ED5A3A /* StatePublisher.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB91EADD24D89BD100ED5A3A /* StatePublisher.swift */; };
+		DB91EAE024D89D8D00ED5A3A /* StatePublisherSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB91EADF24D89D8D00ED5A3A /* StatePublisherSpec.swift */; };
+		DB91EAE224D8A9B500ED5A3A /* StateRelayRemoveDuplicates.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB91EAE124D8A9B500ED5A3A /* StateRelayRemoveDuplicates.swift */; };
 		OBJ_29 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
 		OBJ_40 /* StateRelaySpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_12 /* StateRelaySpec.swift */; };
 		OBJ_43 /* UseCaseKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = "UseCaseKit::UseCaseKit::Product" /* UseCaseKit.framework */; };
@@ -80,6 +83,9 @@
 		DB91EAD424D80AB100ED5A3A /* StateRelay+Extension.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "StateRelay+Extension.swift"; sourceTree = "<group>"; };
 		DB91EAD624D8111D00ED5A3A /* StateRelayMapSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateRelayMapSpec.swift; sourceTree = "<group>"; };
 		DB91EAD924D82B7600ED5A3A /* StateRelayFilterSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateRelayFilterSpec.swift; sourceTree = "<group>"; };
+		DB91EADD24D89BD100ED5A3A /* StatePublisher.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatePublisher.swift; sourceTree = "<group>"; };
+		DB91EADF24D89D8D00ED5A3A /* StatePublisherSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StatePublisherSpec.swift; sourceTree = "<group>"; };
+		DB91EAE124D8A9B500ED5A3A /* StateRelayRemoveDuplicates.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateRelayRemoveDuplicates.swift; sourceTree = "<group>"; };
 		OBJ_12 /* StateRelaySpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateRelaySpec.swift; sourceTree = "<group>"; };
 		OBJ_6 /* Package.swift */ = {isa = PBXFileReference; explicitFileType = sourcecode.swift; path = Package.swift; sourceTree = "<group>"; };
 		"UseCaseKit::UseCaseKit::Product" /* UseCaseKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; path = UseCaseKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -150,6 +156,8 @@
 				OBJ_12 /* StateRelaySpec.swift */,
 				DB91EAD624D8111D00ED5A3A /* StateRelayMapSpec.swift */,
 				DB91EAD924D82B7600ED5A3A /* StateRelayFilterSpec.swift */,
+				DB91EADF24D89D8D00ED5A3A /* StatePublisherSpec.swift */,
+				DB91EAE124D8A9B500ED5A3A /* StateRelayRemoveDuplicates.swift */,
 			);
 			name = UseCaseKitTests;
 			path = Tests/UseCaseKitTests;
@@ -191,6 +199,7 @@
 			children = (
 				DB91EAD224D7D66300ED5A3A /* StateRelay.swift */,
 				DB91EAD424D80AB100ED5A3A /* StateRelay+Extension.swift */,
+				DB91EADD24D89BD100ED5A3A /* StatePublisher.swift */,
 			);
 			name = UseCaseKit;
 			path = Sources/UseCaseKit;
@@ -327,6 +336,7 @@
 			buildActionMask = 0;
 			files = (
 				DB91EAD324D7D66300ED5A3A /* StateRelay.swift in Sources */,
+				DB91EADE24D89BD100ED5A3A /* StatePublisher.swift in Sources */,
 				DB91EAD524D80AB100ED5A3A /* StateRelay+Extension.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -343,7 +353,9 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 0;
 			files = (
+				DB91EAE224D8A9B500ED5A3A /* StateRelayRemoveDuplicates.swift in Sources */,
 				OBJ_40 /* StateRelaySpec.swift in Sources */,
+				DB91EAE024D89D8D00ED5A3A /* StatePublisherSpec.swift in Sources */,
 				DB91EADA24D82B7600ED5A3A /* StateRelayFilterSpec.swift in Sources */,
 				DB91EAD824D8113B00ED5A3A /* StateRelayMapSpec.swift in Sources */,
 			);


### PR DESCRIPTION
Overview
===
Added new internal module `StatePublisher`

`StatePublisher` sends state to `StateRelay`'s receivers and save state.
`StatePublisher` behaves like a RxSwift's BehaviorRelay.