### PR TITLE
:hammer: Add StateSource instead of StateRelay

### DIFF
--- a/Sources/UseCaseKit/DefaultTerminatable.swift
+++ b/Sources/UseCaseKit/DefaultTerminatable.swift
@@ -1,0 +1,17 @@
+//
+// Copyright © 2020 @crexista. All rights reserved.
+//
+
+import Foundation
+
+class DefaultTerminatable: Terminatable {
+    private let closure: () -> Void
+
+    init(closure: @escaping () -> Void) {
+        self.closure = closure
+    }
+
+    func terminate() {
+        closure()
+    }
+}

--- a/Sources/UseCaseKit/StateSource.swift
+++ b/Sources/UseCaseKit/StateSource.swift
@@ -1,0 +1,46 @@
+//
+// Copyright © 2020 @crexista. All rights reserved.
+//
+
+import Foundation
+
+/// This class emits updated state
+public class StateSource<State: Equatable> {
+
+    private let publisher: (@escaping (State) -> Void) -> Terminatable
+
+    init(subscribable: @escaping (@escaping (State) -> Void) -> Terminatable) {
+        self.publisher = subscribable
+    }
+
+    func addSubscriber(subscriber: @escaping (State) -> Void) -> Terminatable {
+        return publisher(subscriber)
+    }
+
+    deinit {
+        print("State Adapter deinit")
+    }
+}
+
+extension StateSource {
+
+    convenience init(store: Store<State>) {
+        self.init(subscribable: { [weak store] in
+            if let key = store?.addSubscriber($0) {
+                return DefaultTerminatable { store?.removeSubscriber(of: key) }
+            } else {
+                return DefaultTerminatable(closure: {})
+            }
+        })
+    }
+}
+
+extension StateSource {
+
+    func map<T: Equatable>(converter: @escaping (State) -> T) -> StateSource<T> {
+        return .init { receiver -> Terminatable in
+            return self.addSubscriber { receiver(converter($0)) }
+        }
+    }
+
+}

--- a/Sources/UseCaseKit/Terminatable.swift
+++ b/Sources/UseCaseKit/Terminatable.swift
@@ -1,0 +1,11 @@
+//
+// Copyright © 2020 @crexista. All rights reserved.
+//
+
+import Foundation
+
+public protocol Terminatable {
+
+    /// This method stop to subscribe state updating.
+    func terminate()
+}

--- a/Sources/UseCaseKit/UseCase+Store.swift
+++ b/Sources/UseCaseKit/UseCase+Store.swift
@@ -18,7 +18,7 @@ public extension UseCase {
         let store = Store(state: state)
         let handler = configure(store)
 
-        return UseCase<CommandType>(dispatcher: Dispatcher<CommandType> { handler($0) }, publisher: store.stateRelay)
+        return UseCase<CommandType>(dispatcher: Dispatcher<CommandType> { handler($0) }, source: store.source)
     }
 
 }

--- a/Sources/UseCaseKit/UseCase.swift
+++ b/Sources/UseCaseKit/UseCase.swift
@@ -11,15 +11,25 @@ public protocol Command {
 public class UseCase<CommandType: Command> {
 
     public let dispatcher: Dispatcher<CommandType>
-    public let state: StateRelay<CommandType.State>
+    private let source: StateSource<CommandType.State>
+    private var terminatables: [Terminatable] = []
 
-    init(dispatcher: Dispatcher<CommandType>, publisher: StateRelay<CommandType.State>) {
+    init(dispatcher: Dispatcher<CommandType>, source: StateSource<CommandType.State>) {
         self.dispatcher = dispatcher
-        self.state = publisher
+        self.source = source
+    }
+
+    public func sink(on queue: DispatchQueue, receiver: @escaping (CommandType.State) -> Void) -> Terminatable {
+        let newReceiver: (CommandType.State) -> Void = { state in
+            queue.async { receiver(state) }
+        }
+        let terminatable = source.addSubscriber(subscriber: newReceiver)
+        terminatables.append(terminatable)
+        return terminatable
     }
 
     deinit {
-        print("usecase deinit")
+        terminatables.forEach { $0.terminate() }
     }
 
 }

--- a/Tests/UseCaseKitTests/MockCommand.swift
+++ b/Tests/UseCaseKitTests/MockCommand.swift
@@ -1,0 +1,12 @@
+//
+// Copyright © 2020 @crexista. All rights reserved.
+//
+
+import Foundation
+import UseCaseKit
+
+enum MockCommand: Command {
+    typealias State = MockState
+    case test1
+    case test2
+}

--- a/Tests/UseCaseKitTests/MockState.swift
+++ b/Tests/UseCaseKitTests/MockState.swift
@@ -1,0 +1,11 @@
+//
+// Copyright © 2020 @crexista. All rights reserved.
+//
+
+import Foundation
+
+enum MockState: String, Equatable {
+    case initial
+    case mock1
+    case mock2
+}

--- a/Tests/UseCaseKitTests/StateSourceSpec.swift
+++ b/Tests/UseCaseKitTests/StateSourceSpec.swift
@@ -1,0 +1,99 @@
+//
+// Copyright © 2020 @crexista. All rights reserved.
+//
+
+@testable import UseCaseKit
+import Quick
+import Nimble
+
+class StateSourceSpec: QuickSpec {
+    override func spec() {
+        var store = Store<MockState>(state: .initial)
+        var source: StateSource<MockState> = store.source
+        var terminatable: Terminatable?
+        var waiter: XCTestExpectation!
+
+        describe("StateSource") {
+
+            beforeEach {
+                waiter = self.expectation(description: "A Closure that subscriber is called")
+                terminatable = nil
+            }
+
+            afterEach { terminatable?.terminate() }
+
+            describe("map Test") {
+                beforeEach {
+                    source = StateSource(subscribable: { callback -> Terminatable in
+                        callback(.mock1)
+                        return DefaultTerminatable {}
+                    })
+                }
+
+                it("calls a closure that registered as subscriber with converted state") {
+                    let test = "test_"
+                    terminatable = source.map { "\(test)\($0)" }.addSubscriber {
+                        expect($0) == "\(test)\(MockState.mock1)"
+                        waiter.fulfill()
+                    }
+                    expect(XCTWaiter.wait(for: [waiter], timeout: 1.0, enforceOrder: true)) == .completed
+                }
+            }
+
+            describe("addSubscriber Test") {
+
+                context("when source is initialized with store") {
+                    beforeEach {
+                        store = Store<MockState>(state: .initial)
+                        source = StateSource(store: store)
+                    }
+                    // swiftlint:disable opening_brace
+                    it("calls a closure that registered with \(MockState.initial)  before store update") {
+                        terminatable = source.addSubscribers(list: [
+                            { expect($0) == .initial; waiter.fulfill() }
+                        ])
+                        expect(XCTWaiter.wait(for: [waiter], timeout: 1.0, enforceOrder: true)) == .completed
+                    }
+
+                    it("calls a closure that registered subscriber at once without updating store") {
+                        // If called subscriber over two times, error will be thrown.
+                        terminatable = source.addSubscribers(list: [ { _ in waiter.fulfill() }, { _ in waiter.fulfill() }])
+                        expect(XCTWaiter.wait(for: [waiter], timeout: 1.0, enforceOrder: true)) == .completed
+                    }
+
+                    it("calls a closure that registered subscriber with \(MockState.mock1) after store update") {
+                        // If called subscriber over two times, error will be thrown.
+                        terminatable = source.addSubscribers(list: [
+                            { expect($0) == .initial },
+                            { expect($0) == .mock1; waiter.fulfill() }
+                        ])
+                        store.update { $0 = .mock1 }
+                        expect(XCTWaiter.wait(for: [waiter], timeout: 1.0, enforceOrder: true)) == .completed
+                    }
+
+                    it("doesn't calls closure that registered subscriber anymore after terminate") {
+                        // If called subscriber over two times, error will be thrown.
+                        terminatable = store.source.addSubscribers(list: [
+                            { expect($0) == .initial },
+                            { expect($0) == .mock1; waiter.fulfill() }
+                        ])
+                        terminatable?.terminate()
+                        store.update { $0 = .mock1 }
+                        expect(XCTWaiter.wait(for: [waiter], timeout: 1.0, enforceOrder: true)) == .timedOut
+                    }
+                }
+
+            }
+        }
+    }
+}
+
+extension StateSource {
+    func addSubscribers(list: [(State) -> Void]) -> Terminatable {
+        var i: Int = 0
+        return addSubscriber {
+            list[i]($0)
+            i += 1
+        }
+    }
+}

--- a/Tests/UseCaseKitTests/UseCaseSpec.swift
+++ b/Tests/UseCaseKitTests/UseCaseSpec.swift
@@ -27,7 +27,7 @@ class UseCaseSpec: QuickSpec {
             context("if UseCase doesn't receive command") {
                 it("returns current state to subscribing closure") {
                     waitUntil { end in
-                        usecase.state.sink { expect($0) == .initial; end() }
+                        _ = usecase.sink(on: .main) { expect($0) == .initial; end() }
                     }
                 }
             }
@@ -36,7 +36,7 @@ class UseCaseSpec: QuickSpec {
                 it("returns mock1 state to subscribing closure") {
                     waitUntil { end in
                         usecase.dispatcher.dispatch(.test1)
-                        usecase.state.sink { expect($0) == .mock1; end() }
+                        _ = usecase.sink(on: .main) { expect($0) == .mock1; end() }
                     }
                 }
             }
@@ -45,23 +45,11 @@ class UseCaseSpec: QuickSpec {
                 it("returns mock2 state to subscribing closure") {
                     waitUntil { end in
                         usecase.dispatcher.dispatch(.test2)
-                        usecase.state.sink { expect($0) == .mock2; end() }
+                        _ = usecase.sink(on: .main) { expect($0) == .mock2; end() }
                     }
                 }
             }
 
         }
     }
-}
-
-enum MockState: Equatable {
-    case initial
-    case mock1
-    case mock2
-}
-
-enum MockCommand: Command {
-    typealias State = MockState
-    case test1
-    case test2
 }

--- a/UseCaseKit.xcodeproj/project.pbxproj
+++ b/UseCaseKit.xcodeproj/project.pbxproj
@@ -22,6 +22,12 @@
 
 /* Begin PBXBuildFile section */
 		253910E651415772E8475E84 /* Pods_UseCaseKit_UseCaseKitTests.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 271BF873D2D8230AEE3B7E32 /* Pods_UseCaseKit_UseCaseKitTests.framework */; };
+		DB162514256BAD2A00C627AC /* Terminatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB162513256BAD2A00C627AC /* Terminatable.swift */; };
+		DB16251C256BF4A100C627AC /* MockState.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB16251B256BF4A100C627AC /* MockState.swift */; };
+		DB162524256BF4F700C627AC /* MockCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB162523256BF4F700C627AC /* MockCommand.swift */; };
+		DB162529256CA5F700C627AC /* DefaultTerminatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB162528256CA5F700C627AC /* DefaultTerminatable.swift */; };
+		DB57762D2550495700903C1D /* StateSource.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB57762C2550495700903C1D /* StateSource.swift */; };
+		DB5776322550626E00903C1D /* StateSourceSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB5776312550626E00903C1D /* StateSourceSpec.swift */; };
 		DB91EAD324D7D66300ED5A3A /* StateRelay.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB91EAD224D7D66300ED5A3A /* StateRelay.swift */; };
 		DB91EAD524D80AB100ED5A3A /* StateRelay+Extension.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB91EAD424D80AB100ED5A3A /* StateRelay+Extension.swift */; };
 		DB91EAD824D8113B00ED5A3A /* StateRelayMapSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB91EAD624D8111D00ED5A3A /* StateRelayMapSpec.swift */; };
@@ -75,6 +81,12 @@
 		ABEF7A1FE50A6AEEF1E81037 /* Pods-UseCaseKit-UseCaseKitTests.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UseCaseKit-UseCaseKitTests.debug.xcconfig"; path = "Target Support Files/Pods-UseCaseKit-UseCaseKitTests/Pods-UseCaseKit-UseCaseKitTests.debug.xcconfig"; sourceTree = "<group>"; };
 		BDFEB4E5C62D2C6BC5023D30 /* Pods-UseCaseKit.debug.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UseCaseKit.debug.xcconfig"; path = "Target Support Files/Pods-UseCaseKit/Pods-UseCaseKit.debug.xcconfig"; sourceTree = "<group>"; };
 		BF6D3B6148FF6A09E5624702 /* Pods-UseCaseKit.release.xcconfig */ = {isa = PBXFileReference; includeInIndex = 1; lastKnownFileType = text.xcconfig; name = "Pods-UseCaseKit.release.xcconfig"; path = "Target Support Files/Pods-UseCaseKit/Pods-UseCaseKit.release.xcconfig"; sourceTree = "<group>"; };
+		DB162513256BAD2A00C627AC /* Terminatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Terminatable.swift; sourceTree = "<group>"; };
+		DB16251B256BF4A100C627AC /* MockState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockState.swift; sourceTree = "<group>"; };
+		DB162523256BF4F700C627AC /* MockCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCommand.swift; sourceTree = "<group>"; };
+		DB162528256CA5F700C627AC /* DefaultTerminatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTerminatable.swift; sourceTree = "<group>"; };
+		DB57762C2550495700903C1D /* StateSource.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateSource.swift; sourceTree = "<group>"; };
+		DB5776312550626E00903C1D /* StateSourceSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateSourceSpec.swift; sourceTree = "<group>"; };
 		DB91EAB724D6DA4200ED5A3A /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		DB91EAB824D6DA4200ED5A3A /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
 		DB91EABB24D6DA6200ED5A3A /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = "<group>"; };
@@ -170,6 +182,9 @@
 				DB91EAE524D9213200ED5A3A /* StoreSpec.swift */,
 				DBFD7F0A24E6C94B006A32A4 /* DispatcherSpec.swift */,
 				DBFD7F0E24EA8C58006A32A4 /* UseCaseSpec.swift */,
+				DB5776312550626E00903C1D /* StateSourceSpec.swift */,
+				DB16251B256BF4A100C627AC /* MockState.swift */,
+				DB162523256BF4F700C627AC /* MockCommand.swift */,
 			);
 			name = UseCaseKitTests;
 			path = Tests/UseCaseKitTests;
@@ -213,6 +228,9 @@
 				DBFD7F0624E6C7D0006A32A4 /* UseCase.swift */,
 				DBFD7F0824E6C839006A32A4 /* Dispatcher.swift */,
 				DBFD7F0C24EA7FBD006A32A4 /* UseCase+Store.swift */,
+				DB57762C2550495700903C1D /* StateSource.swift */,
+				DB162513256BAD2A00C627AC /* Terminatable.swift */,
+				DB162528256CA5F700C627AC /* DefaultTerminatable.swift */,
 			);
 			name = UseCaseKit;
 			path = Sources/UseCaseKit;
@@ -393,11 +411,14 @@
 			buildActionMask = 0;
 			files = (
 				DB91EAD324D7D66300ED5A3A /* StateRelay.swift in Sources */,
+				DB57762D2550495700903C1D /* StateSource.swift in Sources */,
 				DBFD7F0724E6C7D0006A32A4 /* UseCase.swift in Sources */,
 				DB91EAD524D80AB100ED5A3A /* StateRelay+Extension.swift in Sources */,
 				DBFD7F0D24EA7FBD006A32A4 /* UseCase+Store.swift in Sources */,
+				DB162514256BAD2A00C627AC /* Terminatable.swift in Sources */,
 				DB91EAE424D90E0900ED5A3A /* Store.swift in Sources */,
 				DBFD7F0924E6C839006A32A4 /* Dispatcher.swift in Sources */,
+				DB162529256CA5F700C627AC /* DefaultTerminatable.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -420,6 +441,9 @@
 				DBFD7F0B24E6C94B006A32A4 /* DispatcherSpec.swift in Sources */,
 				DB91EAE624D9213200ED5A3A /* StoreSpec.swift in Sources */,
 				DB91EAD824D8113B00ED5A3A /* StateRelayMapSpec.swift in Sources */,
+				DB16251C256BF4A100C627AC /* MockState.swift in Sources */,
+				DB5776322550626E00903C1D /* StateSourceSpec.swift in Sources */,
+				DB162524256BF4F700C627AC /* MockCommand.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
Overview
===
StateRelay has `map`, `filter`, `removeDuplicates`, and that too match.
And StateRelay cannot stop subscribing.
So, this commit adds StateSource instead of StateRelay that just calls subscriber.