### PR TITLE
:sparkles: Add SwiftUI support

### DIFF
--- a/Sources/UseCaseKit/StateObject.swift
+++ b/Sources/UseCaseKit/StateObject.swift
@@ -1,0 +1,24 @@
+//
+// Copyright © 2021 @crexista. All rights reserved.
+//
+
+import Foundation
+
+/// StateObject is state dispatch object for SwiftUI
+@available(iOS 13.0, *)
+public class StateObject<CommandType: Command>: ObservableObject {
+
+    @Published public private(set) var state: CommandType.State
+
+    private let usecase: UseCase<CommandType>
+
+    init(usecase: UseCase<CommandType>) {
+        self.usecase = usecase
+        self.state = usecase.state
+        usecase.sink(on: .main) { [weak self] in self?.state = $0 }
+    }
+
+    public func dispatch(_ command: CommandType) {
+        usecase.dispatch(command)
+    }
+}

--- a/Sources/UseCaseKit/UseCase.swift
+++ b/Sources/UseCaseKit/UseCase.swift
@@ -19,6 +19,10 @@ public class UseCase<CommandType: Command> {
         self.store = store
     }
 
+    var state: CommandType.State {
+        store.currentState
+    }
+
     @discardableResult
     public func sink(on queue: DispatchQueue, receiver: @escaping (CommandType.State) -> Void) -> Terminatable {
         let newReceiver: (CommandType.State) -> Void = { state in
@@ -79,5 +83,15 @@ public extension UseCase {
         let store = Store(state: state)
         let handler = interaction(store)
         self.init(handler: handler, store: store)
+    }
+}
+
+@available(iOS 13.0, *)
+extension UseCase {
+
+    /// Convert to StateObject from UseCase
+    /// - Returns: StateObject
+    func asStateObject() -> StateObject<CommandType> {
+        StateObject(usecase: self)
     }
 }

--- a/Tests/UseCaseKitTests/StateObjectSpec.swift
+++ b/Tests/UseCaseKitTests/StateObjectSpec.swift
@@ -1,0 +1,74 @@
+//
+// Copyright © 2021 @crexista. All rights reserved.
+//
+
+@testable import UseCaseKit
+import Quick
+import Nimble
+
+@available(iOS 13.0, *)
+class StateObjectSpec: QuickSpec {
+
+    override func spec() {
+        var usecase: UseCase<MockCommand>!
+        var stateObject: StateObject<MockCommand>!
+
+        describe("StateObject Subscribing Test") {
+
+            context("`UseCase` state is set to `initial`") {
+
+                beforeEach {
+                    usecase = .test(nil)
+                    stateObject = usecase.asStateObject()
+                }
+
+                it("StateObject's state is `initial`") {
+                    expect(stateObject.state) == .initial
+                }
+
+                it("`StateObject`'s state will change to mock1 after test1 command is dispatched to `UseCase`") {
+                    waitUntil { end in
+                        usecase.dispatch(.test1)
+                        _ = usecase.state
+                        DispatchQueue.main.async { expect(stateObject.state) == .mock1; end() }
+                    }
+                }
+
+                it("`StateObject`'s state will change to mock2 after test2 command is dispatched to `UseCase`") {
+                    waitUntil { end in
+                        usecase.dispatch(.test2)
+                        _ = usecase.state
+                        DispatchQueue.main.async { expect(stateObject.state) == .mock2; end() }
+                    }
+                }
+
+            }
+
+        }
+
+        describe("StateObject dispatch Test") {
+            context("`UseCase` state is set to `initial`") {
+
+                beforeEach {
+                    usecase = .test(nil)
+                    stateObject = usecase.asStateObject()
+                }
+
+                it("`UseCase` state will change to mock1 after test1 command is dispatched to `StateObject`") {
+                    waitUntil { end in
+                        usecase.sink(ignoreFirst: true) { expect($0) == .mock1; end() }
+                        stateObject.dispatch(.test1)
+                    }
+                }
+
+                it("`UseCase` state will change to mock2 after test2 command is dispatched to `StateObject`") {
+                    waitUntil { end in
+                        usecase.sink(ignoreFirst: true) { expect($0) == .mock2; end() }
+                        stateObject.dispatch(.test2)
+                    }
+                }
+
+            }
+        }
+    }
+}

--- a/Tests/UseCaseKitTests/UseCaseSpec.swift
+++ b/Tests/UseCaseKitTests/UseCaseSpec.swift
@@ -88,7 +88,7 @@ class UseCaseSpec: QuickSpec {
 
 extension UseCase where CommandType == MockCommand {
 
-    static func test(_ deinitWaiter: XCTestExpectation) -> UseCase {
+    static func test(_ deinitWaiter: XCTestExpectation?) -> UseCase {
         return .init(.initial) { store in
             return .onReceive {
                 switch $0 {
@@ -96,7 +96,7 @@ extension UseCase where CommandType == MockCommand {
                 case .test2: store.update { $0 = .mock2 }
                 }
             } onDeinit: {
-                deinitWaiter.fulfill()
+                deinitWaiter?.fulfill()
             }
         }
     }

--- a/UseCaseKit.xcodeproj/project.pbxproj
+++ b/UseCaseKit.xcodeproj/project.pbxproj
@@ -30,6 +30,8 @@
 		DB91EAE424D90E0900ED5A3A /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB91EAE324D90E0900ED5A3A /* Store.swift */; };
 		DB91EAE624D9213200ED5A3A /* StoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB91EAE524D9213200ED5A3A /* StoreSpec.swift */; };
 		DBFA3BC02771E62500220808 /* DefaultTerminatableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFA3BBF2771E62500220808 /* DefaultTerminatableSpec.swift */; };
+		DBFA3BC22772F99300220808 /* StateObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFA3BC12772F99300220808 /* StateObject.swift */; };
+		DBFA3BC52772FAE400220808 /* StateObjectSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFA3BC32772FAAA00220808 /* StateObjectSpec.swift */; };
 		DBFD7F0724E6C7D0006A32A4 /* UseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFD7F0624E6C7D0006A32A4 /* UseCase.swift */; };
 		DBFD7F0F24EA8C58006A32A4 /* UseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFD7F0E24EA8C58006A32A4 /* UseCaseSpec.swift */; };
 		OBJ_29 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
@@ -83,6 +85,8 @@
 		DB91EAE324D90E0900ED5A3A /* Store.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Store.swift; sourceTree = "<group>"; };
 		DB91EAE524D9213200ED5A3A /* StoreSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StoreSpec.swift; sourceTree = "<group>"; };
 		DBFA3BBF2771E62500220808 /* DefaultTerminatableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTerminatableSpec.swift; sourceTree = "<group>"; };
+		DBFA3BC12772F99300220808 /* StateObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateObject.swift; sourceTree = "<group>"; };
+		DBFA3BC32772FAAA00220808 /* StateObjectSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateObjectSpec.swift; sourceTree = "<group>"; };
 		DBFD7F0624E6C7D0006A32A4 /* UseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UseCase.swift; sourceTree = "<group>"; };
 		DBFD7F0E24EA8C58006A32A4 /* UseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UseCaseSpec.swift; sourceTree = "<group>"; };
 		F4F5D95C7858B070556A2907 /* Pods_UseCaseKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UseCaseKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -162,6 +166,7 @@
 				DBFA3BBF2771E62500220808 /* DefaultTerminatableSpec.swift */,
 				DB16251B256BF4A100C627AC /* MockState.swift */,
 				DB162523256BF4F700C627AC /* MockCommand.swift */,
+				DBFA3BC32772FAAA00220808 /* StateObjectSpec.swift */,
 			);
 			name = UseCaseKitTests;
 			path = Tests/UseCaseKitTests;
@@ -203,6 +208,7 @@
 				DBFD7F0624E6C7D0006A32A4 /* UseCase.swift */,
 				DB162513256BAD2A00C627AC /* Terminatable.swift */,
 				DB162528256CA5F700C627AC /* DefaultTerminatable.swift */,
+				DBFA3BC12772F99300220808 /* StateObject.swift */,
 			);
 			name = UseCaseKit;
 			path = Sources/UseCaseKit;
@@ -384,6 +390,7 @@
 			files = (
 				DBFD7F0724E6C7D0006A32A4 /* UseCase.swift in Sources */,
 				DB162514256BAD2A00C627AC /* Terminatable.swift in Sources */,
+				DBFA3BC22772F99300220808 /* StateObject.swift in Sources */,
 				DB91EAE424D90E0900ED5A3A /* Store.swift in Sources */,
 				DB162529256CA5F700C627AC /* DefaultTerminatable.swift in Sources */,
 			);
@@ -404,6 +411,7 @@
 				DBFD7F0F24EA8C58006A32A4 /* UseCaseSpec.swift in Sources */,
 				DB91EAE624D9213200ED5A3A /* StoreSpec.swift in Sources */,
 				DB16251C256BF4A100C627AC /* MockState.swift in Sources */,
+				DBFA3BC52772FAE400220808 /* StateObjectSpec.swift in Sources */,
 				DB162524256BF4F700C627AC /* MockCommand.swift in Sources */,
 				DBFA3BC02771E62500220808 /* DefaultTerminatableSpec.swift in Sources */,
 			);


### PR DESCRIPTION
Overview
===
Add `StateObject` and converter that changes `UseCase` to `StateObject` for SwiftUI.