### PR TITLE
:sparkle: Add combine support

### DIFF
--- a/Sources/UseCaseKit/UseCase+Combine.swift
+++ b/Sources/UseCaseKit/UseCase+Combine.swift
@@ -1,0 +1,61 @@
+// 
+// Copyright © 2021 @crexista. All rights reserved.
+//
+
+import Foundation
+import Combine
+
+@available(iOS 13.0, *)
+extension UseCase {
+
+    class Subscription<S: Subscriber>: Combine.Subscription where S.Input == CommandType.State, S.Failure == Never {
+
+        private let usecase: UseCase<CommandType>
+        private var subscriber: S
+        private var terminatable: Terminatable?
+
+        init(usecase: UseCase<CommandType>, subscriber: S) {
+            self.subscriber = subscriber
+            self.usecase = usecase
+        }
+
+        func request(_ demand: Subscribers.Demand) {
+            terminatable = usecase.sink { [subscriber] in
+                _ = subscriber.receive($0)
+            }
+        }
+
+        func cancel() {
+            terminatable?.terminate()
+        }
+
+    }
+
+    struct Publisher: Combine.Publisher {
+        typealias Output = CommandType.State
+        typealias Failure = Never
+
+        private let usecase: UseCase<CommandType>
+
+        init(usecase: UseCase<CommandType>) {
+            self.usecase = usecase
+        }
+
+        func receive<S>(subscriber: S) where S: Subscriber, Never == S.Failure, CommandType.State == S.Input {
+            let subscription = Subscription(usecase: usecase, subscriber: subscriber)
+            subscriber.receive(subscription: subscription)
+        }
+    }
+
+}
+
+@available(iOS 13.0, *)
+public extension UseCase {
+
+    /// Make an AnyPublisher that is publishing `UseCase`'s state.
+    ///
+    /// - Returns: An `AnyPublisher` that is publishing `UseCase`'s state
+    func asAnyPublisher() -> AnyPublisher<CommandType.State, Never> {
+        return Publisher(usecase: self).eraseToAnyPublisher()
+    }
+}

--- a/Sources/UseCaseKit/UseCase+StateObject.swift
+++ b/Sources/UseCaseKit/UseCase+StateObject.swift
@@ -1,0 +1,15 @@
+// 
+// Copyright © 2021 @crexista. All rights reserved.
+//
+
+import Foundation
+
+@available(iOS 13.0, *)
+public extension UseCase {
+
+    /// Converts `self` to `StateObject`.
+    /// - Returns: A `StateObject` that represents `self`.
+    func asStateObject() -> StateObject<CommandType> {
+        StateObject(usecase: self)
+    }
+}

--- a/Tests/UseCaseKitTests/UseCasePublisherSpec.swift
+++ b/Tests/UseCaseKitTests/UseCasePublisherSpec.swift
@@ -1,0 +1,90 @@
+//
+// Copyright © 2021 @crexista. All rights reserved.
+//
+
+@testable import UseCaseKit
+import Quick
+import Nimble
+import Combine
+
+@available(iOS 13.0, *)
+class UseCasePublisherSpec: QuickSpec {
+
+    override func spec() {
+        var usecase: UseCase<MockCommand>?
+        var publisher: AnyPublisher<MockCommand.State, Never>?
+        var sinkWaiter: XCTestExpectation!
+        var deinitWaiter: XCTestExpectation!
+        var cancelable: Cancellable?
+        var expectedState: MockCommand.State?
+
+        describe("UseCase's AnyPublisher Test") {
+
+            beforeEach {
+                deinitWaiter = self.expectation(description: "DeinitListener Waiter")
+                sinkWaiter = self.expectation(description: "A Closure that subscriber is called")
+                usecase = .test(deinitWaiter)
+                publisher = usecase?.asAnyPublisher()
+            }
+
+            describe("Publishing stored state test") {
+
+                beforeEach {
+                    cancelable = publisher?.sink { expectedState = $0; sinkWaiter.fulfill() }
+                }
+
+                it("A state that is stored by usecase is published immediately after `sink`") {
+                    expect(expectedState) == .initial
+                    expect(XCTWaiter.wait(for: [sinkWaiter], timeout: 1.0, enforceOrder: true)) == .completed
+                }
+
+                it("`UseCase`'s subscribing count goes up") {
+                    expect(usecase?.subscribersCount) == 1
+                }
+
+            }
+
+            describe("Dispatch Command Test") {
+                beforeEach {
+                    cancelable = publisher?.dropFirst().sink { expectedState = $0; sinkWaiter.fulfill() }
+                }
+
+                it("A state that is sent after test1 command is dispatched to `UseCase` is mock1") {
+                    usecase?.dispatch(.test1)
+                    expect(expectedState) == .mock1
+                    expect(XCTWaiter.wait(for: [sinkWaiter], timeout: 1.0, enforceOrder: true)) == .completed
+                }
+
+                it("A state that is sent after test2 command is dispatched to `UseCase` is mock2") {
+                    usecase?.dispatch(.test2)
+                    expect(expectedState) == .mock2
+                    expect(XCTWaiter.wait(for: [sinkWaiter], timeout: 1.0, enforceOrder: true)) == .completed
+                }
+            }
+
+            describe("Cancel Test") {
+
+                beforeEach {
+                    cancelable = publisher?.dropFirst().sink { _ in  sinkWaiter.fulfill() }
+                    cancelable?.cancel()
+                }
+
+                it("subscriber is not called if usecase is command dispatched") {
+                    usecase?.dispatch(.test1)
+                    expect(XCTWaiter.wait(for: [sinkWaiter], timeout: 1.0, enforceOrder: true)) == .timedOut
+                }
+
+                it("`UseCase`'s subscribing count goes down") {
+                    expect(usecase?.subscribersCount) == 0
+                }
+
+                it("usecase set nil it will be released") {
+                    usecase = nil
+                    publisher = nil
+                    expect(XCTWaiter.wait(for: [deinitWaiter], timeout: 1.0, enforceOrder: true)) == .completed
+                }
+            }
+        }
+
+    }
+}

--- a/UseCaseKit.xcodeproj/project.pbxproj
+++ b/UseCaseKit.xcodeproj/project.pbxproj
@@ -27,11 +27,14 @@
 		DB16251C256BF4A100C627AC /* MockState.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB16251B256BF4A100C627AC /* MockState.swift */; };
 		DB162524256BF4F700C627AC /* MockCommand.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB162523256BF4F700C627AC /* MockCommand.swift */; };
 		DB162529256CA5F700C627AC /* DefaultTerminatable.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB162528256CA5F700C627AC /* DefaultTerminatable.swift */; };
+		DB7A0D57277B059D0014B599 /* UseCase+Combine.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7A0D56277B059D0014B599 /* UseCase+Combine.swift */; };
+		DB7A0D59277B08050014B599 /* UseCase+StateObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB7A0D58277B08050014B599 /* UseCase+StateObject.swift */; };
 		DB91EAE424D90E0900ED5A3A /* Store.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB91EAE324D90E0900ED5A3A /* Store.swift */; };
 		DB91EAE624D9213200ED5A3A /* StoreSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DB91EAE524D9213200ED5A3A /* StoreSpec.swift */; };
 		DBFA3BC02771E62500220808 /* DefaultTerminatableSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFA3BBF2771E62500220808 /* DefaultTerminatableSpec.swift */; };
 		DBFA3BC22772F99300220808 /* StateObject.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFA3BC12772F99300220808 /* StateObject.swift */; };
 		DBFA3BC52772FAE400220808 /* StateObjectSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFA3BC32772FAAA00220808 /* StateObjectSpec.swift */; };
+		DBFA3BC727731D3C00220808 /* UseCasePublisherSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFA3BC627731D3C00220808 /* UseCasePublisherSpec.swift */; };
 		DBFD7F0724E6C7D0006A32A4 /* UseCase.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFD7F0624E6C7D0006A32A4 /* UseCase.swift */; };
 		DBFD7F0F24EA8C58006A32A4 /* UseCaseSpec.swift in Sources */ = {isa = PBXBuildFile; fileRef = DBFD7F0E24EA8C58006A32A4 /* UseCaseSpec.swift */; };
 		OBJ_29 /* Package.swift in Sources */ = {isa = PBXBuildFile; fileRef = OBJ_6 /* Package.swift */; };
@@ -78,6 +81,8 @@
 		DB16251B256BF4A100C627AC /* MockState.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockState.swift; sourceTree = "<group>"; };
 		DB162523256BF4F700C627AC /* MockCommand.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MockCommand.swift; sourceTree = "<group>"; };
 		DB162528256CA5F700C627AC /* DefaultTerminatable.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTerminatable.swift; sourceTree = "<group>"; };
+		DB7A0D56277B059D0014B599 /* UseCase+Combine.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UseCase+Combine.swift"; sourceTree = "<group>"; };
+		DB7A0D58277B08050014B599 /* UseCase+StateObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UseCase+StateObject.swift"; sourceTree = "<group>"; };
 		DB91EAB724D6DA4200ED5A3A /* Quick.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Quick.framework; path = Carthage/Build/iOS/Quick.framework; sourceTree = "<group>"; };
 		DB91EAB824D6DA4200ED5A3A /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/iOS/Nimble.framework; sourceTree = "<group>"; };
 		DB91EABB24D6DA6200ED5A3A /* Nimble.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = Nimble.framework; path = Carthage/Build/Mac/Nimble.framework; sourceTree = "<group>"; };
@@ -87,6 +92,7 @@
 		DBFA3BBF2771E62500220808 /* DefaultTerminatableSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DefaultTerminatableSpec.swift; sourceTree = "<group>"; };
 		DBFA3BC12772F99300220808 /* StateObject.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateObject.swift; sourceTree = "<group>"; };
 		DBFA3BC32772FAAA00220808 /* StateObjectSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = StateObjectSpec.swift; sourceTree = "<group>"; };
+		DBFA3BC627731D3C00220808 /* UseCasePublisherSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UseCasePublisherSpec.swift; sourceTree = "<group>"; };
 		DBFD7F0624E6C7D0006A32A4 /* UseCase.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UseCase.swift; sourceTree = "<group>"; };
 		DBFD7F0E24EA8C58006A32A4 /* UseCaseSpec.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UseCaseSpec.swift; sourceTree = "<group>"; };
 		F4F5D95C7858B070556A2907 /* Pods_UseCaseKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Pods_UseCaseKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -167,6 +173,7 @@
 				DB16251B256BF4A100C627AC /* MockState.swift */,
 				DB162523256BF4F700C627AC /* MockCommand.swift */,
 				DBFA3BC32772FAAA00220808 /* StateObjectSpec.swift */,
+				DBFA3BC627731D3C00220808 /* UseCasePublisherSpec.swift */,
 			);
 			name = UseCaseKitTests;
 			path = Tests/UseCaseKitTests;
@@ -209,6 +216,8 @@
 				DB162513256BAD2A00C627AC /* Terminatable.swift */,
 				DB162528256CA5F700C627AC /* DefaultTerminatable.swift */,
 				DBFA3BC12772F99300220808 /* StateObject.swift */,
+				DB7A0D56277B059D0014B599 /* UseCase+Combine.swift */,
+				DB7A0D58277B08050014B599 /* UseCase+StateObject.swift */,
 			);
 			name = UseCaseKit;
 			path = Sources/UseCaseKit;
@@ -392,7 +401,9 @@
 				DB162514256BAD2A00C627AC /* Terminatable.swift in Sources */,
 				DBFA3BC22772F99300220808 /* StateObject.swift in Sources */,
 				DB91EAE424D90E0900ED5A3A /* Store.swift in Sources */,
+				DB7A0D59277B08050014B599 /* UseCase+StateObject.swift in Sources */,
 				DB162529256CA5F700C627AC /* DefaultTerminatable.swift in Sources */,
+				DB7A0D57277B059D0014B599 /* UseCase+Combine.swift in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -412,6 +423,7 @@
 				DB91EAE624D9213200ED5A3A /* StoreSpec.swift in Sources */,
 				DB16251C256BF4A100C627AC /* MockState.swift in Sources */,
 				DBFA3BC52772FAE400220808 /* StateObjectSpec.swift in Sources */,
+				DBFA3BC727731D3C00220808 /* UseCasePublisherSpec.swift in Sources */,
 				DB162524256BF4F700C627AC /* MockCommand.swift in Sources */,
 				DBFA3BC02771E62500220808 /* DefaultTerminatableSpec.swift in Sources */,
 			);


### PR DESCRIPTION
Overview
===
Add `asAnyPublisher()` method to `UseCase`, to convert `UseCase` to AnyPubilsher.
This makes it possible to retrieve changes in `UseCase`'s state via AnyPublisher.

Note
===
In order to implement this update, the following two changes have been made.

1. The `Store` used to hold all the `Subscribers` and notify them of events.
   Now it delegates the responsibility to `UseCase` and only notifies `UseCase` when the State is updated.
2. The `UseCase` now detects `Store`'s state changes and notifies all Listeners of the changes