### PR TITLE
:recycle: Store has been changed to update its status asynchronously

### DIFF
--- a/Sources/UseCaseKit/Store.swift
+++ b/Sources/UseCaseKit/Store.swift
@@ -32,16 +32,17 @@ public class Store<State: Equatable> {
     ///   - transient: A Boolean value that the update is transient either or not.
     ///   - updater: A closure that update state. This closure is thread safe.
     public func update(transient: Bool = false, updater: @escaping (inout State) -> Void) {
-        queue.sync {
-            var newState = state
+        queue.async { [weak self] in
+            guard let self = self else { return }
+            var newState = self.state
             updater(&newState)
-            state = transient ? state : newState
-            listener?(newState)
+            self.state = transient ? self.state : newState
+            self.listener?(newState)
         }
     }
 
     func set(stateListener: @escaping (State) -> Void) {
-        queue.async { [weak self] in
+        queue.sync { [weak self] in
             self?.listener = stateListener
         }
     }

--- a/Sources/UseCaseKit/UseCase.swift
+++ b/Sources/UseCaseKit/UseCase.swift
@@ -58,7 +58,7 @@ public class UseCase<CommandType: Command> {
     }
 
     private func publish(_ state: CommandType.State) {
-        queue.sync { [weak self] in
+        queue.async { [weak self] in
             self?.subscribers.values.forEach { $0(state) }
         }
     }

--- a/Tests/UseCaseKitTests/ObservableUseCaseSpec.swift
+++ b/Tests/UseCaseKitTests/ObservableUseCaseSpec.swift
@@ -7,7 +7,6 @@ import Quick
 import Nimble
 import XCTest
 
-@available(iOS 13.0, *)
 class ObservableUseCaseSpec: QuickSpec {
 
     override func spec() {
@@ -28,19 +27,13 @@ class ObservableUseCaseSpec: QuickSpec {
                 }
 
                 it("`StateObject`'s state will change to mock1 after test1 command is dispatched to `UseCase`") {
-                    waitUntil { end in
-                        usecase.dispatch(.test1)
-                        _ = usecase.state
-                        DispatchQueue.main.async { expect(observableMock.state) == .mock1; end() }
-                    }
+                    usecase.dispatch(.test1)
+                    await expect(observableMock.state == .mock1).toEventually(beTrue())
                 }
 
                 it("`StateObject`'s state will change to mock2 after test2 command is dispatched to `UseCase`") {
-                    waitUntil { end in
-                        usecase.dispatch(.test2)
-                        _ = usecase.state
-                        DispatchQueue.main.async { expect(observableMock.state) == .mock2; end() }
-                    }
+                    usecase.dispatch(.test2)
+                    await expect(observableMock.state == .mock2).toEventually(beTrue())
                 }
 
             }
@@ -56,14 +49,14 @@ class ObservableUseCaseSpec: QuickSpec {
                 }
 
                 it("`UseCase` state will change to mock1 after test1 command is dispatched to `StateObject`") {
-                    waitUntil { end in
+                    await waitUntil { end in
                         usecase.sink(ignoreFirst: true) { expect($0) == .mock1; end() }
                         observableMock.dispatch(.test1)
                     }
                 }
 
                 it("`UseCase` state will change to mock2 after test2 command is dispatched to `StateObject`") {
-                    waitUntil { end in
+                    await waitUntil { end in
                         usecase.sink(ignoreFirst: true) { expect($0) == .mock2; end() }
                         observableMock.dispatch(.test2)
                     }

--- a/Tests/UseCaseKitTests/StoreSpec.swift
+++ b/Tests/UseCaseKitTests/StoreSpec.swift
@@ -43,7 +43,7 @@ class StoreSpec: QuickSpec {
                     }
 
                     it("new State is notified to listener") {
-                        expect(updatedState) == newState
+                        await expect(updatedState == newState).toEventually(beTrue())
                     }
                 }
 
@@ -57,7 +57,7 @@ class StoreSpec: QuickSpec {
                     }
 
                     it("new State is notified to listener") {
-                        expect(updatedState) == newState
+                        await expect(updatedState == newState).toEventually(beTrue())
                     }
                 }
 

--- a/Tests/UseCaseKitTests/UseCasePublisherSpec.swift
+++ b/Tests/UseCaseKitTests/UseCasePublisherSpec.swift
@@ -47,19 +47,17 @@ class UseCasePublisherSpec: QuickSpec {
 
             describe("Dispatch Command Test") {
                 beforeEach {
-                    cancelable = publisher?.dropFirst().sink { expectedState = $0; sinkWaiter.fulfill() }
+                    cancelable = publisher?.dropFirst().sink { expectedState = $0 }
                 }
 
                 it("A state that is sent after test1 command is dispatched to `UseCase` is mock1") {
                     usecase?.dispatch(.test1)
-                    expect(expectedState) == .mock1
-                    expect(XCTWaiter.wait(for: [sinkWaiter], timeout: 1.0, enforceOrder: true)) == .completed
+                    await expect(expectedState == .mock1).toEventually(beTrue())
                 }
 
                 it("A state that is sent after test2 command is dispatched to `UseCase` is mock2") {
                     usecase?.dispatch(.test2)
-                    expect(expectedState) == .mock2
-                    expect(XCTWaiter.wait(for: [sinkWaiter], timeout: 1.0, enforceOrder: true)) == .completed
+                    await expect(expectedState == .mock2).toEventually(beTrue())
                 }
             }
 


### PR DESCRIPTION
Overview
====
Store used to update with a sync queue, but this caused a deadlock when update was called inside the update's callback, so it was changed to update the state with an async queue.

Other
===
Fixed deprecation warning in test code.
(Changed to use `await` keyword, on asynchronously test)