### PR TITLE
Bump up SwiftLint version

### DIFF
--- a/.swiftlint.yml
+++ b/.swiftlint.yml
@@ -6,7 +6,6 @@ excluded:
 analyzer_rules:
   - unused_import
 opt_in_rules:
-  - anyobject_protocol
   - attributes
   - closure_end_indentation
   - closure_spacing

--- a/Package.swift
+++ b/Package.swift
@@ -15,7 +15,7 @@ let package = Package(
     dependencies: [
         // Dependencies declare other packages that this package depends on.
         // .package(url: /* package url */, from: "1.0.0"),
-        .package(url: "https://github.com/realm/SwiftLint.git", revision: "d98fd53"),
+        .package(url: "https://github.com/realm/SwiftLint.git", .upToNextMinor(from: "0.55.1")),
         .package(url: "https://github.com/Quick/Quick.git", from: "6.1.0"),
         .package(url: "https://github.com/Quick/Nimble.git", from: "11.2.1")
     ],
@@ -25,11 +25,11 @@ let package = Package(
         .target(
             name: "UseCaseKit",
             dependencies: [],
-            plugins: [.plugin(name: "SwiftLintPlugin", package: "SwiftLint")]),
+            plugins: [.plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLint")]),
         .testTarget(
             name: "UseCaseKitTests",
             dependencies: ["UseCaseKit", "Quick", "Nimble"],
-            plugins: [.plugin(name: "SwiftLintPlugin", package: "SwiftLint")])
+            plugins: [.plugin(name: "SwiftLintBuildToolPlugin", package: "SwiftLint")])
     ]
 )
     


### PR DESCRIPTION
Bump up SwiftLint version to 0.55.1 and remove deprecated SwiftLint rule `anyobject_protocol`

> * The `anyobject_protocol` rule is now deprecated and will be completely removed
>   in a future release because it is now handled by the Swift compiler.  
>   [JP Simard](https://github.com/jpsim)

https://github.com/realm/SwiftLint/blob/3421f5f46d23b539e1afbc7e74c9275b26635997/CHANGELOG.md?plain=1#L1346-L1348